### PR TITLE
added bus changes capability

### DIFF
--- a/src/Bus.java
+++ b/src/Bus.java
@@ -5,6 +5,8 @@ public class Bus {
     private int id;
     private int routeId;
     private int routeIndex;
+    private int newRouteId;
+    private int newRouteIndex;
     private int numPassengersRiding;
     private int numPassengersUnloading;
     private int numPassengersLoading;
@@ -34,13 +36,40 @@ public class Bus {
         this.fuelCapacity = fuel_capacity;
         this.avgSpeed = speed;
         this.stopId = Main.routes.get(this.routeId).getStopIdByIndex(this.routeIndex);
+
+        // If client updates bus route and route index, those values will be reflected in these two attributes.
+        // The reason for adding these two extra fields (a.o.t. overriding routeId and routeIndex) is that, for calculating distance and time from bus' current stop to next stop, Main looks at routeId and routeIndex to determine current stop.
+        // When a bus is moved, Main compares these two fields to routeId and routeIndex. If they're not equal, Main computes distance and time between current stop and stop along new route
+        // If they are equal, Main computes distance and time between current stop and the next stop on the same route.
+        this.newRouteId = route_id;
+        this.newRouteIndex = route_index;
     }
     // Access methods
     public int getRouteId() {
         return this.routeId;
     }
+    public void setRouteId(int routeId) {
+        this.routeId = routeId;
+    }
     public int getRouteIndex() {
         return this.routeIndex;
+    }
+    public int getNewRouteId() {
+        return this.newRouteId;
+    }
+    public int getNewRouteIndex() {
+        return this.newRouteIndex;
+    }
+    // called by both client and updateEventExecutionTimes
+    public void setNewRouteId(int newRouteId) {
+        this.newRouteId = newRouteId;
+    }
+    public void setNewRouteIndex(int newRouteIndex) {
+        this.newRouteIndex = newRouteIndex;
+    }
+    public Stop getCurrentStop() {
+        int current_stop_id = Main.routes.get(this.routeId).getStopIdByIndex(this.routeIndex);
+        return Main.stops.get(current_stop_id);
     }
     public int getNumPassengersRiding() {
         return this.numPassengersRiding;
@@ -52,11 +81,16 @@ public class Bus {
         return this.avgSpeed;
     }
     public int getNextStop() {
-        int route_size = Main.routes.get(this.routeId).getListStopIds().size();
-        if (this.routeIndex == (route_size - 1)) {
-            return Main.routes.get(this.routeId).getStopIdByIndex((0));
-        } else {
-            return Main.routes.get(this.routeId).getStopIdByIndex((this.routeIndex + 1));
+        if (newRouteId == routeId) {
+            // get next stop along the current route
+            int route_size = Main.routes.get(this.routeId).getListStopIds().size();
+            if (this.routeIndex == (route_size - 1)) {
+                return Main.routes.get(this.routeId).getStopIdByIndex((0));
+            } else {
+                return Main.routes.get(this.routeId).getStopIdByIndex((this.routeIndex + 1));
+            }
+        } else { //get the designated stop on the new route
+            return Main.routes.get(this.newRouteId).getStopIdByIndex(this.newRouteIndex);
         }
     }
     public void setRouteIndex(int index){
@@ -68,14 +102,8 @@ public class Bus {
     public double calculateDistance() {
         int current_stopID, next_stopID;
         double [] current_location, next_location;
-        int route_size = Main.routes.get(this.routeId).getListStopIds().size();
-        if (this.routeIndex == route_size - 1) {
-            current_stopID = Main.routes.get(this.routeId).getStopIdByIndex(this.routeIndex);
-            next_stopID = Main.routes.get(this.routeId).getStopIdByIndex((0));
-        } else {
-            current_stopID = Main.routes.get(this.routeId).getStopIdByIndex(this.routeIndex);
-            next_stopID = Main.routes.get(this.routeId).getStopIdByIndex((this.routeIndex + 1));
-        }
+        current_stopID = Main.routes.get(this.routeId).getStopIdByIndex(this.routeIndex);
+        next_stopID = getNextStop();
         current_location = Main.stops.get(current_stopID).getLocation();
         next_location = Main.stops.get(next_stopID).getLocation();
         this.distanceNextStop = 70.0 * Math.sqrt((Math.pow((next_location[0] - current_location[0]),2)+
@@ -85,5 +113,19 @@ public class Bus {
     public int calculateTravelTime(double distance) {
         this.travelTimeNextStop = 1 + ((int)distance * 60 / ((int)this.getAvgSpeed()));
         return this.travelTimeNextStop;
+    }
+
+    // Below methods were added to support bus changes capability
+    public void setSpeed(double newSpeed) {
+        this.avgSpeed = newSpeed;
+    }
+
+    public void setCapacity(int newPassengerCapacity) {
+        this.maxCapacity = newPassengerCapacity;
+    }
+
+    public void changeRoute(int newRouteId, int newRouteIndex) {
+        this.newRouteId = newRouteId;
+        this.newRouteIndex = newRouteIndex;
     }
 }

--- a/src/BusCapacityChange.java
+++ b/src/BusCapacityChange.java
@@ -1,0 +1,12 @@
+public class BusCapacityChange extends BusChange {
+    private int new_capacity;
+
+    public BusCapacityChange(ChangeType type, int bus_id, int new_capacity) {
+        super(type, bus_id);
+        this.new_capacity = new_capacity;
+    }
+
+    public int getNewCapacity() {
+        return this.new_capacity;
+    }
+}

--- a/src/BusChange.java
+++ b/src/BusChange.java
@@ -1,0 +1,18 @@
+abstract class BusChange {
+    enum ChangeType {
+        SPEED, ROUTE, CAPACITY;
+    }
+
+    private ChangeType type;
+    private int bus_id;
+
+    public BusChange(ChangeType type, int bus_id) {
+        this.type = type;
+        this.bus_id = bus_id;
+    }
+
+    public ChangeType getChangeType() {
+        return this.type;
+    }
+
+}

--- a/src/BusRouteChange.java
+++ b/src/BusRouteChange.java
@@ -1,0 +1,18 @@
+public class BusRouteChange extends BusChange {
+    private int new_route_id;
+    private int new_route_index;
+
+    public BusRouteChange(ChangeType type, int bus_id, int new_route_id, int new_route_index) {
+        super(type, bus_id);
+        this.new_route_id = new_route_id;
+        this.new_route_index = new_route_index;
+    }
+
+    public int getNewRouteId() {
+        return this.new_route_id;
+    }
+
+    public int getNewRouteIndex() {
+        return this.new_route_index;
+    }
+}

--- a/src/BusSpeedChange.java
+++ b/src/BusSpeedChange.java
@@ -1,0 +1,12 @@
+public class BusSpeedChange extends BusChange {
+    private double new_speed;
+
+    public BusSpeedChange(ChangeType type, int bus_id, double new_speed) {
+        super(type, bus_id);
+        this.new_speed = new_speed;
+    }
+    
+    public double getNewSpeed() {
+        return this.new_speed;
+    }
+}

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,13 +1,12 @@
-import java.util.Scanner;
+import java.util.*;
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 import java.lang.*;
 
 public class Main {
     public static Map<Integer, Bus> buses = new HashMap();
     public static Map<Integer,Stop> stops = new HashMap();
     public static Map<Integer,Route> routes = new HashMap();
+    public static List<BusChange> bus_changes = new ArrayList<>();
     public static void main(String[] args) {
         // Initialize variables
         int event_index = -1;
@@ -69,6 +68,11 @@ public class Main {
             // Step 2: Determine which bus should be selected for processing(based on lowest arrival time)
             queue.chooseNextEvent();
             current_bus_processing = queue.listEvents.get(queue.currentEventId).getBusId();
+            Bus bus = buses.get(current_bus_processing);
+
+            // Step 4: update bus changes (if any)
+            evaluateChanges(bus);
+
             // Step 3: Determine which stop the bus will travel to next (based on the current location and route)
             next_stop_id = buses.get(current_bus_processing).getNextStop();
             // Step 4: Calculate the distance and travel time between the current and next stops
@@ -80,6 +84,27 @@ public class Main {
             System.out.println("b:"+current_bus_processing +"->s:"+next_stop_id+"@"+next_time+"//p:"+next_passengers+"/f:0");
             // Step 6: Update system state and generate new events as needed.
             queue.updateEventExecutionTimes(queue.currentEventId, next_time);
+
+        }
+    }
+
+    public static void evaluateChanges(Bus bus) {
+        for (BusChange change : bus_changes) {
+            BusChange.ChangeType type = change.getChangeType();
+            switch (type) {
+                case SPEED:
+                    BusSpeedChange speedChange = (BusSpeedChange) change;
+                    bus.setSpeed(speedChange.getNewSpeed());
+                    break;
+                case CAPACITY:
+                    BusCapacityChange capacityChange = (BusCapacityChange) change;
+                    bus.setCapacity(capacityChange.getNewCapacity());
+                    break;
+                case ROUTE:
+                    BusRouteChange routeChange = (BusRouteChange) change;
+                    bus.changeRoute(routeChange.getNewRouteId(), routeChange.getNewRouteIndex());
+                    break;
+            }
         }
     }
 }

--- a/src/Queue.java
+++ b/src/Queue.java
@@ -44,14 +44,27 @@ public class Queue {
         this.currentEventId = lowestEventId;
         return;
     }
+    // final step: make routeId and routeIndex the same as newRouteId and newRouteIndex so that Main can tell if client has changed bus route in future steps
+    // pre-condition: routeId and routeIndex may be same or different than newRouteId and newRouteIndex (latter is true if client requested bus route change)
+    // post-condition: bus routeId and routeIndex will be equal to newRouteId and newRouteIndex, respectively
     public void updateEventExecutionTimes(int eventIndex, int eventRank){
         this.listEvents.get(eventIndex).setRank(eventRank);
         int bus_id = this.listEvents.get(eventIndex).getBusId();
-        int route_id = Main.buses.get(bus_id).getRouteId();
-        if((Main.buses.get(bus_id).getRouteIndex() + 1)>= Main.routes.get(route_id).getListStopIds().size()){
-            Main.buses.get(bus_id).setRouteIndex(0);
-        } else {
-            Main.buses.get(bus_id).setRouteIndex((Main.buses.get(bus_id).getRouteIndex() + 1));
+        Bus bus = Main.buses.get(bus_id);
+        if (bus.getRouteId() == bus.getNewRouteId()) { //client has not changed route since last move_bus event was processed
+            // make routeIndex and newRouteIndex equal to the index of the next stop on the current route
+            int route_id = bus.getRouteId();
+            if((bus.getRouteIndex() + 1)>= Main.routes.get(route_id).getListStopIds().size()){
+                bus.setRouteIndex(0);
+                bus.setNewRouteIndex(0);
+            } else {
+                bus.setRouteIndex((bus.getRouteIndex() + 1));
+                bus.setNewRouteIndex((bus.getRouteIndex() + 1));
+            }
+        } else { //client has changed route since last move_bus event was processed
+            // set the bus route and stop index to be newRouteId and newRouteIndex, respectively
+            bus.setRouteId(bus.getNewRouteId());
+            bus.setRouteIndex(bus.getNewRouteIndex());
         }
         return;
     }


### PR DESCRIPTION
This PR introduces:
- capability for making bus changes by the client.

The client will now be able to make bus changes by clicking certain buttons on the GUI. @comtety Please make 3 buttons `setNewSpeed`, `setNewCapacity`, and `changeBusRoute` that add objects of type `BusSpeedChange`, `BusCapacityChange` and `BusRouteChange` to the `eventChanges` list in Main.

New Classes BusChange, Bus(Speed/Route/Capacity)Change:
Because each type of change is handled differently and has a different number of arguments, I created abstract BusChange class which represents a bus change. It is subclassed into BusSpeedChange, BusRouteChange, and BusCapacityChange, which can be pushed onto the BusChange list when the client requests a bus change from the GUI.

Inside Main:
Created evaluateChanges method which takes BusChange objects off of busChanges list and modifies the corresponding Bus object's state based on the type of the change (e.g., bus speed, route, or capacity)
Invoked evaluateChanges before passenger exchange and time and distance to next stop calculation

inside Bus:
Added two new fields newRouteId and newRouteIndex (and associated getters and setters) to keep track of when client requests route change
Added setSpeed, setCapacity, and changeRoute (as laid out in UML diagram) to accommodate bus changes.
Updated Bus.getNextStop method to return the next stop on the bus’ current route or the designated stop on the new route if the client requested a route change. 
Refactored Bus.calculateDistance to use Bus.getNextStop to eliminate redundant code

Inside Queue:
Updated Queue.updateEventExecutionTimes to set the bus’s route index to the index of the next stop on the current route or change the bus route id and index to match the designated route and stop index on that new route if client requested a route change.


TODO 
refactor invocation of evaluateChanges from main() into updateEventExecutionTimes() once that is integrated in the code